### PR TITLE
Updates to 

### DIFF
--- a/examples/dag-tests.ipynb
+++ b/examples/dag-tests.ipynb
@@ -32,21 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = DiGraph([\n",
-    "    (first, second),\n",
-    "    (second, third),\n",
-    "    (third, fourth)\n",
-    "])\n",
-    "dag = webber.DAG(G)\n",
-    "dag.execute()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "dag.visualize()"
    ]
   },

--- a/examples/dag_complex.py
+++ b/examples/dag_complex.py
@@ -3,6 +3,9 @@ A simple example of Webber's functionality --
 Compares overhead of synchronous exection in Webber with Python proper,
 generally on the magnitude of hundreths of seconds.
 """
+
+#TODO: Investigate why this repeats itself.
+
 from time import sleep, time
 from typing import Union
 from webber import DAG

--- a/examples/dag_err.py
+++ b/examples/dag_err.py
@@ -36,7 +36,8 @@ if __name__ == "__main__":
     dep_event: str = dag.add_node(dependent)
 
     _ = dag.add_edge(err_event, dependent)
-    _ = dag.add_edge(err_event, follower, continue_on=webber.Condition.Failure)
+    _ = dag.add_edge(ind_event, follower)
+    _ = dag.add_edge(err_event, follower, continue_on=webber.Condition.AnyCase)
     
     dag.execute(print_exc=False)
     dag.visualize()

--- a/examples/dag_err.py
+++ b/examples/dag_err.py
@@ -21,11 +21,11 @@ def independent():
 
 def dependent():
     """Make a statement (if you can!)"""
-    print("I am dependent on erroneous.")
+    print("I should not run. I am dependent on erroneous succeeding.")
 
 def follower():
     """Make a statement after erroneous."""
-    print("I should follow erroneous, but I'm not dependent on its success.")
+    print("I should follow erroneous, no matter what.")
 
 if __name__ == "__main__":
 
@@ -36,8 +36,7 @@ if __name__ == "__main__":
     dep_event: str = dag.add_node(dependent)
 
     _ = dag.add_edge(err_event, dependent)
-    _ = dag.add_edge(err_event, follower, continue_on=webber.Condition.AnyCase)
-    _ = dag.add_edge(independent, dependent)
-
-    dag.execute(print_exc=True)
+    _ = dag.add_edge(err_event, follower, continue_on=webber.Condition.Failure)
+    
+    dag.execute(print_exc=False)
     dag.visualize()

--- a/examples/dag_err.py
+++ b/examples/dag_err.py
@@ -21,7 +21,11 @@ def independent():
 
 def dependent():
     """Make a statement (if you can!)"""
-    print("I am dependent.")
+    print("I am dependent on erroneous.")
+
+def follower():
+    """Make a statement after erroneous."""
+    print("I should follow erroneous, but I'm not dependent on its success.")
 
 if __name__ == "__main__":
 
@@ -32,6 +36,8 @@ if __name__ == "__main__":
     dep_event: str = dag.add_node(dependent)
 
     _ = dag.add_edge(err_event, dependent)
+    _ = dag.add_edge(err_event, follower, continue_on=webber.Condition.AnyCase)
     _ = dag.add_edge(independent, dependent)
 
-    dag.execute()
+    dag.execute(print_exc=True)
+    dag.visualize()

--- a/examples/dag_test_complex.py
+++ b/examples/dag_test_complex.py
@@ -1,3 +1,5 @@
+## DEPRECATED / NOT CURRENTLY SUPPORTED
+
 """
 A simple example of Webber's functionality --
 Compares overhead of synchronous exection in Webber with Python proper,

--- a/webber/__init__.py
+++ b/webber/__init__.py
@@ -10,4 +10,4 @@ if _sys.platform not in __supported__:
     err_msg = f"Webber {__version__} is only supported on these platforms: {', '.join(__supported__)}"
     raise NotImplementedError(err_msg)
 
-from .core import DAG
+from .core import DAG, Condition

--- a/webber/core/__init__.py
+++ b/webber/core/__init__.py
@@ -132,7 +132,9 @@ class DAG:
                                         if not _edges.continue_on_success(graph.edges.get(e))
                                     ]
                                 skipped  = skipped.union(skipping)
-                                carryon  = set(graph.successors(event)).difference(skipping)
+                                for n in skipping:
+                                    skipped  = skipped.union(_nx.descendants(graph, n))
+                                carryon  = set(graph.successors(event)).difference(skipped)
                                 starting = [
                                     successor for successor in carryon if
                                     run_conditions_met(successor)

--- a/webber/core/__init__.py
+++ b/webber/core/__init__.py
@@ -58,7 +58,7 @@ class _OutputLogger:
         self._redirector.__exit__(exc_type, exc_value, traceback)
 
 def _event_wrapper(_callable: callable, _name: str, _args, _kwargs):
-    with _OutputLogger(str(_uuid.uuid1()), "INFO", _name) as _:
+    with _OutputLogger(str(_uuid.uuid4()), "INFO", _name) as _:
         return _callable(*_args, **_kwargs)
 
 class DAG:

--- a/webber/core/__init__.py
+++ b/webber/core/__init__.py
@@ -96,7 +96,7 @@ class DAG:
                                     return False
                             case Condition.AnyCase:
                                 pass
-                        return True
+                    return True
 
                 skip  = graph.nodes.data("skip", default=False) 
                 retry = {n: [c+1, {}] for n,c in graph.nodes.data("retry", default=0)}

--- a/webber/credits/__init__.py
+++ b/webber/credits/__init__.py
@@ -1,0 +1,2 @@
+__VERSION__ = '0.0.2'
+__platforms__ = ["linux", "linux2", "win32"]

--- a/webber/edges/__init__.py
+++ b/webber/edges/__init__.py
@@ -5,17 +5,16 @@ import enum as _enum
 
 __all__ = ["valid_node", "valid_nodes", "valid_dag", "validate_nodes", "label_node"]
 
-class Condition(_enum.Enum):
+class Condition(_enum.IntEnum):
     Success = 0
     Failure = 1
-    Skip    = 2
     AnyCase = 3
 
 def continue_on_failure(edge: dict) -> bool:
     return edge['Condition'] in (Condition.Failure, Condition.AnyCase)
 
-def continue_on_skip(edge: dict) -> bool:
-    return edge['Condition'] in (Condition.Skip, Condition.AnyCase)
+def continue_on_success(edge: dict) -> bool:
+    return edge['Condition'] in (Condition.Success, Condition.AnyCase)
 
 def valid_node(node: _T.Union[str, _T.Callable]) -> bool:
     return (isinstance(node,str) or callable(node))

--- a/webber/edges/__init__.py
+++ b/webber/edges/__init__.py
@@ -1,8 +1,21 @@
 import typing as _T
 import uuid as _uuid
 import networkx as _nx
+import enum as _enum
 
 __all__ = ["valid_node", "valid_nodes", "valid_dag", "validate_nodes", "label_node"]
+
+class Condition(_enum.Enum):
+    Success = 0
+    Failure = 1
+    Skip    = 2
+    AnyCase = 3
+
+def continue_on_failure(edge: dict) -> bool:
+    return edge['Condition'] in (Condition.Failure, Condition.AnyCase)
+
+def continue_on_skip(edge: dict) -> bool:
+    return edge['Condition'] in (Condition.Skip, Condition.AnyCase)
 
 def valid_node(node: _T.Union[str, _T.Callable]) -> bool:
     return (isinstance(node,str) or callable(node))

--- a/webber/edges/__init__.py
+++ b/webber/edges/__init__.py
@@ -50,5 +50,4 @@ def get_root(graph: _nx.DiGraph) -> list:
     ))
 
 def label_node(node: _T.Callable) -> str:
-    return f"{node.__name__}__{_uuid.uuid1()}"
-
+    return f"{node.__name__}__{_uuid.uuid4()}"

--- a/webber/viz/__init__.py
+++ b/webber/viz/__init__.py
@@ -47,6 +47,9 @@ def generate_pyvis_network(graph: _nx.DiGraph) -> _Network:
         layout='hierarchical',
     )
 
+    generations = [sorted(generation) for generation in _nx.topological_generations(graph)]
+    node_generation = lambda n: [i for i, G in enumerate(generations) if n in G][0]
+
     for n in graph.nodes:
         node = graph.nodes[n]
         args, kwargs = [], {}
@@ -87,7 +90,8 @@ def generate_pyvis_network(graph: _nx.DiGraph) -> _Network:
             label=node['name'],
             shape='circle' if len(graph) < 4 else 'box',
             title= node_title,
-            labelHighlightBold=True
+            labelHighlightBold=True,
+            level=node_generation(n)
         )
     for source_edge, dest_edge in graph.edges:
         network.add_edge(source_edge, dest_edge)
@@ -134,7 +138,8 @@ def generate_vis_js_script(graph: _nx.DiGraph) -> str:
                     },
                     "layout": {
                         "hierarchical": {
-                            "direction": "UD",                            "blockShifting": true,
+                            "direction": "UD",
+                            "blockShifting": true,
                             "edgeMinimization": false,
                             "enabled": true,
                             "parentCentralization": true,


### PR DESCRIPTION
- **Conditional Edges + Node Skip/Retry settings are in preview!**

**Change-log**

- Nodes can now be skipped, or set up to retry on failure, using DAG-level calls.

- Edges - or relationships between nodes - have been updated to support:
   - Execution of child node on parent's success (default, webber.Condition.Success).
   - Execution of child node on parent's failure (webber.Condition.Failure).
   - Execution of child node in any case (webber.Condition.AnyCase).
   
- Node/logger IDs updated from UUID1 to UUID4.
- Disabling exception trace printouts by default.